### PR TITLE
when ranger exits the terminal buffer is removed

### DIFF
--- a/plugin/ranger.vim
+++ b/plugin/ranger.vim
@@ -35,6 +35,7 @@ endfunction
 function! s:RangerChooserForNeoVim(dirname)
     let callback = {'tempname': tempname()}
     function! callback.on_exit()
+    exec 'bdelete!'
         try
             if filereadable(self.tempname)
                 let names = readfile(self.tempname)


### PR DESCRIPTION
This is only for neovim. 

The problem is that the terminal does not exit after the running instance of ranger terminates. So you end up with empty term buffers cluttering up your open buffers.

I hope you and other will find this minor fix helpfull.
