### PR TITLE
Added configurable g:ranger_on_exit hook

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,10 +17,16 @@ When you open a file in ranger, it will be opened in vim.
 You could also select multiple files and open'em all at once (use ``v`` to select multiple files in ranger).
 BTW, don't use it with nerdtree at the same time. 
 
+Configuration
+-------------
+
+Custom command to run when ranger exits: `let g:ranger_on_exit = ''`
+
 Tips
 -----
 
 You can add ``nnoremap <f3> :tabe %:p:h<cr>`` to your .vimrc so that you could use ``<f3>`` to open new files in new tab.
+Clear up lingering buffers after ranger exits: `let g:ranger_on_exit = 'bw!'`
 
 Known issue
 -----------

--- a/plugin/ranger.vim
+++ b/plugin/ranger.vim
@@ -35,6 +35,9 @@ endfunction
 function! s:RangerChooserForNeoVim(dirname)
     let s:callback = {'tempname': tempname()}
     function! s:callback.on_exit(id, exit_status, event) dict abort
+        if exists('g:ranger_on_exit')
+          exec g:ranger_on_exit
+        endif
         try
             if filereadable(self.tempname)
                 let names = readfile(self.tempname)


### PR DESCRIPTION
Hey, we had our different needs regarding closing buffers (22278af3ac25b79d4b2dd3667b4e234af07ec974).
I've been using my own fork since and would rather not, so here's a PR to make it configurable without changing the defaults.